### PR TITLE
initialized upload form w/ api endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3648,6 +3648,20 @@
         "shallow-clone": "^0.1.2"
       }
     },
+    "cloudinary-core": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.10.3.tgz",
+      "integrity": "sha512-uI7jASEcfjYBdoTb2uj4wgTB0cWPDwrQV4paYFOgEdU22z74eeJ1zI83ew2kuNnXBnbuPZFt310H329UfiHG2w=="
+    },
+    "cloudinary-react": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/cloudinary-react/-/cloudinary-react-1.6.2.tgz",
+      "integrity": "sha512-9wk37NAGzjMLt0SF9ftOcbeoUaJATH9iaMc8DCUwMq+looOgtWoMuY9W/5rJo559oGK+48cNBUXnT+1Ft9SyKg==",
+      "requires": {
+        "cloudinary-core": "^2.10.3",
+        "prop-types": "^15.6.2"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
     "bootstrap": "^4.5.0",
+    "cloudinary-core": "^2.10.3",
+    "cloudinary-react": "^1.6.2",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/components/uploadImageForm.js
+++ b/src/components/uploadImageForm.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from "react"
+import axios from "axios"
+
+export default function UploadImageForm() {
+  const [fileInputState, setFileInputState] = useState("")
+  // const [selectedFile, setSelectedFile] = useState("")
+  const [previewSource, setPreviewSource] = useState()
+
+  const handleFileInputChange = (event) => {
+    const file = event.target.files[0]
+    previewFile(file)
+  }
+
+  const previewFile = (file) => {
+    const reader = new FileReader()
+    reader.readAsDataURL(file)
+    reader.onloadend = () => {
+      setPreviewSource(reader.result)
+    }
+  }
+
+  const handleSubmitFile = (event) => {
+    console.log("submitting")
+    event.preventDefault()
+    if (!previewSource) return
+    uploadImage(previewSource)
+  }
+
+  const uploadImage = async (base64EncodedImage) => {
+    try {
+      await fetch("/api/upload", {
+        method: "POST",
+        body: JSON.stringify({ data: base64EncodedImage }),
+        headers: { "Content-Type": "application/json" },
+      })
+      setFileInputState("")
+      setPreviewSource("")
+      // setSuccessMsg("Image uploaded successfully")
+    } catch (err) {
+      console.error(err)
+      // setErrMsg("Something went wrong!")
+    }
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleSubmitFile}>
+        <input
+          type="file"
+          name="image"
+          onChange={handleFileInputChange}
+          value={fileInputState}
+        ></input>
+        <button type="submit">Submit</button>
+      </form>
+      {previewSource && <img src={previewSource} style={{ height: "150px" }} />}
+    </div>
+  )
+}

--- a/src/pages/admin.js
+++ b/src/pages/admin.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux"
 import { useHistory } from "react-router-dom"
 import { selectToken } from "../store/user/selectors"
 import { logOut } from "../store/user/actions"
+import UploadImageForm from "../components/uploadImageForm"
 
 export default function Admin() {
   const dispatch = useDispatch()
@@ -18,7 +19,10 @@ export default function Admin() {
   return (
     <div>
       <h2>Admin page</h2>
-      <div>some form over here</div>
+      <br></br>
+      <UploadImageForm />
+      <br></br>
+      <br></br>
       <button onClick={() => dispatch(logOut())}>Log out</button>
     </div>
   )


### PR DESCRIPTION
set up basic image upload form at '/admin'

## Cloudinary
I used cloudinary because I thought I'd need an image manager like this, however my REST api will have to work twice as hard to post/get requests to both cloudinary and my DB, while not really using Coudinary's potential as file manager.
This is has probably to do with me overseeing some functionality I need while creating the wireframe. 

I made another diagram of the workflow how it is using Cloudinary and as I thought it does seem a little odd.

_workflow with Cloudinary_
![Screenshot 2020-07-24 at 09 53 24](https://user-images.githubusercontent.com/65892566/88371376-31a56c00-cd94-11ea-9da4-c6bb5260ab59.png)

another possibility is saving the images as base64EncodedImage string to the database.

_bypassing cloudinary_
![Screenshot 2020-07-24 at 09 53 30](https://user-images.githubusercontent.com/65892566/88371542-83e68d00-cd94-11ea-98b1-d51eaf737e04.png)

I also have done some research on Sanity CMS system and will do some tests with that and implement it on another branch.
