### PR TITLE
Feature enable scroll trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3638,6 +3638,11 @@
         }
       }
     },
+    "clean-react-props": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/clean-react-props/-/clean-react-props-0.4.0.tgz",
+      "integrity": "sha512-8KKm9sC/cUax4SBWwSY5a3W44aJKOUQg39Bo3fRErp3/mF8D1kMN9xc1lvQGmvkK/AmpH2Xh/UYVZOJMcxoy9w=="
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -8342,6 +8347,11 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -11450,6 +11460,34 @@
         "webpack-dev-server": "3.10.3",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "4.3.1"
+      }
+    },
+    "react-scroll-trigger": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/react-scroll-trigger/-/react-scroll-trigger-0.6.6.tgz",
+      "integrity": "sha512-pC2jelj94XeBuHmFuJagsCb/WPyYDcwbRNmsL/uSboYDiNl+fksFbVHGflzg7JZMQ0+3LNRqWHZivK+5dUHURA==",
+      "requires": {
+        "@types/react": "^16.9.44",
+        "@types/react-dom": "^16.9.6",
+        "clean-react-props": "^0.4.0",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.9.46",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
+          "integrity": "sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==",
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "csstype": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+          "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw=="
+        }
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
+    "react-scroll-trigger": "^0.6.6",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import "./App.scss"
 import { useDispatch } from "react-redux"
 import { fetchTimelineItems, fetchMenuItems } from "./store/homepage/actions"
 import { Switch, Route } from "react-router-dom"
-import Homepage from "./pages/homepage"
+import Homepage from "./pages/Homepage"
 
 export default function App() {
   const dispatch = useDispatch()

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -1,0 +1,50 @@
+import React, { createRef, useState, useEffect } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { selectTimelineItems } from "../store/homepage/selectors"
+
+import "./MenuItem.scss"
+
+const MenuItem = (props) => {
+  const { menu } = props
+  const timelineItems = useSelector(selectTimelineItems)
+  const [itemHeight, setItemHeight] = useState(0)
+  const [itemRef, setItemRef] = useState()
+
+  // console.log("wat is in de itemRef?", itemRef)
+
+  useEffect(() => {
+    if (!itemRef) return
+    setItemHeight(itemRef.offsetHeight)
+  }, [itemRef])
+
+  console.log("dit is de menuItem hoogtn", menu._id, itemHeight)
+
+  return (
+    <div
+      className="MenuItem"
+      key={menu._id}
+      id={menu._id}
+      ref={(ref) => {
+        setItemRef(ref)
+      }}
+    >
+      {timelineItems.map((item) => {
+        // console.log(item)
+        if (menu.order === item.postOrder)
+          return (
+            <img
+              key={item._id}
+              src={item.imageUrl}
+              ref={(ref) => {
+                console.log("image ref offsetHeight", ref.offsetHeight)
+                // if (!itemRef) return
+                // setItemHeight(itemRef.offsetHeight)
+              }}
+            ></img>
+          )
+      })}
+    </div>
+  )
+}
+
+export default MenuItem

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -10,35 +10,35 @@ const MenuItem = (props) => {
   const [itemHeight, setItemHeight] = useState(0)
   const [itemRef, setItemRef] = useState()
 
-  // console.log("wat is in de itemRef?", itemRef)
+  // useEffect(() => {
+  //   if (!itemRef) return
+  //   setItemHeight(itemRef.offsetHeight)
+  // }, [itemRef])
 
-  useEffect(() => {
-    if (!itemRef) return
-    setItemHeight(itemRef.offsetHeight)
-  }, [itemRef])
-
-  console.log("dit is de menuItem hoogtn", menu._id, itemHeight)
+  console.log(`menuItem order: ${menu.order}, menuItem height: ${itemHeight}`)
 
   return (
     <div
       className="MenuItem"
-      key={menu._id}
       id={menu._id}
       ref={(ref) => {
         setItemRef(ref)
       }}
     >
       {timelineItems.map((item) => {
-        // console.log(item)
+        // const clientSortedAlphabetical = [...item].sort(
+        //   (a, b) => a.title - b.title
+        // )
+
+        // console.log("what is item?", item)
         if (menu.order === item.postOrder)
           return (
             <img
               key={item._id}
               src={item.imageUrl}
               ref={(ref) => {
-                console.log("image ref offsetHeight", ref.offsetHeight)
-                // if (!itemRef) return
-                // setItemHeight(itemRef.offsetHeight)
+                if (!itemRef) return
+                setItemHeight(itemRef.offsetHeight)
               }}
             ></img>
           )

--- a/src/components/MenuItem.scss
+++ b/src/components/MenuItem.scss
@@ -1,0 +1,12 @@
+@import "../style/config";
+
+.MenuItem {
+  margin-bottom: 5px;
+  img {
+    display: inline-block;
+    width: 100%;
+    margin: 0px;
+    padding: 0px;
+    margin-bottom: 5px;
+  }
+}

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -9,11 +9,21 @@ import {
 
 export default function Timeline() {
   const menuItems = useSelector(selectMenuItems)
+  const [itemHeight, setItemHeight] = useState(0)
+  const [itemRef, setItemRef] = useState()
+
+  // console.log("what is itemRef in Timeline?", itemRef)
+  console.log("what is itemHeight in Timeline?", itemHeight)
+
+  useEffect(() => {
+    if (!itemRef) return
+    setItemHeight(itemRef.offsetHeight)
+  }, [itemRef])
 
   return (
-    <div className="Timeline">
+    <div className="Timeline" ref={setItemRef}>
       {menuItems.map((menu) => (
-        <MenuItem menu={menu} />
+        <MenuItem menu={menu} key={menu._id} />
       ))}
     </div>
   )

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,35 +1,20 @@
-import React from "react"
+import React, { useEffect, createRef, useState } from "react"
 import "./Timeline.scss"
-import { useDispatch, useSelector } from "react-redux"
+import { useSelector } from "react-redux"
+import MenuItem from "./MenuItem"
 import {
   selectTimelineItems,
   selectMenuItems,
 } from "../store/homepage/selectors"
-import "../pages/homepage.scss"
 
 export default function Timeline() {
-  const timelineItems = useSelector(selectTimelineItems)
   const menuItems = useSelector(selectMenuItems)
 
   return (
     <div className="Timeline">
-      {menuItems.map((menu) => {
-        const orderNumber = menu.order
-        return (
-          <div className="menuItems" key={menu._id} id={menu._id}>
-            {timelineItems.map((item) => {
-              if (orderNumber === item.postOrder)
-                return (
-                  <img
-                    key={item._id}
-                    className="item"
-                    src={item.imageUrl}
-                  ></img>
-                )
-            })}
-          </div>
-        )
-      })}
+      {menuItems.map((menu) => (
+        <MenuItem menu={menu} />
+      ))}
     </div>
   )
 }

--- a/src/components/Timeline.scss
+++ b/src/components/Timeline.scss
@@ -1,22 +1,29 @@
 @import "../style/config";
 
 .Timeline {
-  position: absolute;
+  position: relative;
+  left: 45%;
   padding: 20px;
   padding-left: 40px;
   padding-right: 10px;
   top: 0;
-  width: 50%;
+  width: 55%;
   right: 0px;
   box-sizing: border-box;
-  .menuItems {
-    margin-bottom: 5px;
-    img {
-      display: inline-block;
-      width: 100%;
-      margin: 0px;
-      padding: 0px;
-      margin-bottom: 5px;
+  // .menuItem {
+  //   margin-bottom: 5px;
+  //   img {
+  //     display: inline-block;
+  //     width: 100%;
+  //     margin: 0px;
+  //     padding: 0px;
+  //     margin-bottom: 5px;
+  //   }
+  // }
+  .scrolltest {
+    height: 2000px;
+    .test {
+      top: 50%;
     }
   }
 }

--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -1,13 +1,13 @@
 import React from "react"
-import "./homepage.scss"
+import "./Homepage.scss"
 import Menubar from "../components/Menubar"
 import BodyText from "../components/BodyText"
 import Timeline from "../components/Timeline"
 
 export default function Homepage() {
   return (
-    <div className="homepage">
-      <div className="content-container">
+    <div className="Homepage">
+      <div className="menu-container">
         <Menubar />
         <BodyText />
       </div>

--- a/src/pages/homepage.scss
+++ b/src/pages/homepage.scss
@@ -1,7 +1,7 @@
 @import "../style/config";
 
-.homepage {
-  position: absolute;
+.Homepage {
+  // position: absolute;
   padding: 20px;
   width: 100%;
   height: 100%;
@@ -9,7 +9,7 @@
   left: 0;
   box-sizing: border-box;
   overflow-x: hidden;
-  .content-container {
+  .menu-container {
     position: fixed;
     width: 44%;
   }

--- a/src/store/homepage/actions.js
+++ b/src/store/homepage/actions.js
@@ -21,7 +21,6 @@ export const fetchMenuItems = () => async (dispatch, getState) => {
     dispatch(fetchMenuItemsSuccess(data))
     //set default chapter to the 1st in the list
     dispatch(setSelectedMenuItem(data[0]._id))
-    console.log("waht is selected current chapter?", data[0]._id)
   })
 }
 const fetchMenuItemsSuccess = (data) => {


### PR DESCRIPTION
## scroll trigger

### scroll-trigger api
I tried to use _scroll-trigger_ (https://www.npmjs.com/package/react-scroll-trigger) to show which menuItem's images are in viewpoint in the timeline, I wanted to use that to set **setSelectedMenuItem** in the store. Unfortunately the api behaved very random so I had to think of something else.
### ref
I created a separate component for **MenuItem** (the container div in Timeline that holds all images from that specific menuItem) to keep the **Timeline** component clean.
Every menuItem get a _ref_ that is stored locally, every image gets a _ref_ that I use to determine if the image is rendered already, if so I set the itemHeight of the **menuItem** containing all images. This way the eventual size seems correct.
### Calculate
What I need to to now is to calculate the total of **Timeline** when everything is rendered, so I can _calculate_ a scrollTop value that I can use to fire a **setSelectedMenuItem** action.

![Screenshot 2020-08-12 at 16 24 56](https://user-images.githubusercontent.com/65892566/90027085-6aac6e80-dcb8-11ea-8a13-c9f87fec7ff2.png)
_console log print of menuItem ordernumber and its height_

**ToDo**
But since I'm a bit stuck on how to do this I'll insert a styling intermezzo to copy as much of the old website as possible.
