### PR TITLE
Feature scroll event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1359,6 +1359,33 @@
       "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
       "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
     },
+    "@sanity/block-content-to-hyperscript": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-2.0.10.tgz",
+      "integrity": "sha512-xT3iEmZkK0fvO5PDFpn9GMWGfvOopvbrRCBU48XxpFoTxRrfsHhxbRy8J0eND1HGXHUENkIKv5jbohtGd1MiVg==",
+      "requires": {
+        "@sanity/generate-help-url": "^0.140.0",
+        "@sanity/image-url": "^0.140.15",
+        "hyperscript": "^2.0.2",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "@sanity/generate-help-url": {
+          "version": "0.140.0",
+          "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
+          "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw=="
+        }
+      }
+    },
+    "@sanity/block-content-to-react": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-2.0.7.tgz",
+      "integrity": "sha512-oSriTf/3Ihnxp6AjEGiVjNPA2Iq/IFaWg4Frn5msGq5GT8N1kwLwxduig1OSn87UA15LNwiai9LAJwBR2k9lIg==",
+      "requires": {
+        "@sanity/block-content-to-hyperscript": "^2.0.10",
+        "prop-types": "^15.6.2"
+      }
+    },
     "@sanity/client": {
       "version": "1.149.18",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-1.149.18.tgz",
@@ -1386,6 +1413,14 @@
       "version": "1.149.16",
       "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-1.149.16.tgz",
       "integrity": "sha512-+lJPqs88i6KMo21Twr6YnZ1hjIOQ8Utz5xTFrTn+55egU4dh+bI03cI4AC1LpTzQsuefKvz22/12pz9ejHGKhw=="
+    },
+    "@sanity/image-url": {
+      "version": "0.140.19",
+      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.19.tgz",
+      "integrity": "sha512-itPCTXNyF2MFdXMlwmpcXEiZU7AvSxyQpOaCQ3x8uODIl3GY22KAHYzz6rIGzWU63u0DN/Y8O1ChsblPLqnI5Q==",
+      "requires": {
+        "@sanity/client": "^1.149.13"
+      }
     },
     "@sanity/observable": {
       "version": "1.149.16",
@@ -3219,6 +3254,11 @@
         }
       }
     },
+    "browser-split": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -3600,6 +3640,14 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "class-list": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+      "requires": {
+        "indexof": "0.0.1"
       }
     },
     "class-utils": {
@@ -6724,6 +6772,14 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
+    "html-element": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+      "requires": {
+        "class-list": "~0.1.1"
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -6872,6 +6928,16 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "hyperscript": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+      "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+      "requires": {
+        "browser-split": "0.0.0",
+        "class-list": "~0.1.0",
+        "html-element": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6969,6 +7035,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "infer-owner": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@sanity/block-content-to-react": "^2.0.7",
     "@sanity/client": "^1.149.18",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/src/components/BodyText.js
+++ b/src/components/BodyText.js
@@ -1,22 +1,20 @@
 import React from "react"
 import "./BodyText.scss"
+import BlockContent from "@sanity/block-content-to-react"
 import { useSelector } from "react-redux"
-import { selectMenuItems, selectedPost } from "../store/homepage/selectors"
+import { selectCurrentMenuItem } from "../store/homepage/selectors"
 
 export default function BodyText() {
-  const menuItems = useSelector(selectMenuItems)
-  const selectedPostItem = useSelector(selectedPost)
+  const menuItem = useSelector(selectCurrentMenuItem)
 
   return (
     <div className="BodyText">
-      {menuItems.map((menu) => {
-        if (menu._id === selectedPostItem[0])
-          return (
-            <div key={menu._id}>
-              <p>{menu.body}</p>
-            </div>
-          )
-      })}
+      {menuItem &&
+        menuItem.body
+          .filter(({ _type }) => _type === "block")
+          .map((block) => (
+            <BlockContent key={menuItem.id} blocks={block} serializers={{}} />
+          ))}
     </div>
   )
 }

--- a/src/components/Menubar.js
+++ b/src/components/Menubar.js
@@ -1,27 +1,36 @@
 import React from "react"
 import "./Menubar.scss"
-import { useDispatch, useSelector } from "react-redux"
-import { setSelectedPost } from "../store/homepage/actions"
-import { selectMenuItems } from "../store/homepage/selectors"
+import { Link } from "react-router-dom"
+import { useSelector } from "react-redux"
+import {
+  selectMenuItemData,
+  selectCurrentMenuItem,
+} from "../store/homepage/selectors"
 
 export default function Menubar() {
-  const dispatch = useDispatch()
-  const menuItems = useSelector(selectMenuItems)
-  // console.log("what are the chapter items?", menuItems)
+  const menuItems = useSelector(selectMenuItemData)
+  const currentMenuItem = useSelector(selectCurrentMenuItem)
+
+  // sets selected menuItem title to color black
+  const selectedMenuItem = (title) => {
+    if (currentMenuItem && title === currentMenuItem.title) {
+      return { color: "black" }
+    }
+  }
 
   return (
     <div className="menubar">
-      {menuItems.map((menu) => {
-        return (
-          <a
-            href={`#${menu._id}`}
-            key={menu._id}
-            onClick={() => dispatch(setSelectedPost(menu._id))}
-          >
-            {menu.title}
-          </a>
-        )
-      })}
+      {menuItems.map((item) => (
+        <Link
+          key={item.id}
+          to="/"
+          // fires callback function (scrollIntoView)
+          onClick={item.callback}
+          style={selectedMenuItem(item.title)}
+        >
+          {item.title}
+        </Link>
+      ))}
     </div>
   )
 }

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -1,48 +1,83 @@
-import React, { useState, useEffect } from "react"
-import { useSelector } from "react-redux"
-import { selectPosts } from "../store/homepage/selectors"
-
+import React, { useState, useEffect, useCallback } from "react"
 import "./Post.scss"
+import { useSelector, useDispatch } from "react-redux"
+import { selectMenuItemsPosts } from "../store/homepage/selectors"
+import {
+  setCurrentMenuItem,
+  setMenuItemCallback,
+} from "../store/homepage/actions"
 
 const Post = (props) => {
-  const { menu } = props
-  const Posts = useSelector(selectPosts)
-  const [postHeight, setPostHeight] = useState(0)
-  const [postRef, setPostRef] = useState()
+  const dispatch = useDispatch()
+  const { menuItem } = props
+  // selects posts of corresponding menuItem
+  const posts = useSelector(selectMenuItemsPosts(menuItem))
+  // local states that store DOM node info
+  const [menuItemOffsetTop, setMenuItemOffsetTop] = useState(0)
+  const [menuItemOffsetBottom, setMenuItemOffsetBottom] = useState(0)
+  const [postsLoaded, setPostsLoaded] = useState(0)
 
-  // useEffect(() => {
-  //   if (!postRef) return
-  //   setPostHeight(postRef.offsetHeight)
-  // }, [postRef])
+  const scrollHandler = (ev) => {
+    // amount of pixels scrolled
+    const { scrollTop } = ev.target.scrollingElement
+    // sets boundries offset top
+    if (
+      scrollTop > menuItemOffsetTop - 20 &&
+      scrollTop - window.innerHeight < menuItemOffsetTop - 20
+    ) {
+      // sets new current menuItem
+      dispatch(setCurrentMenuItem(menuItem))
+    } else if (
+      // boundries for offset bottom
+      scrollTop < menuItemOffsetBottom - 20 &&
+      scrollTop + window.innerHeight > menuItemOffsetBottom - 20
+    ) {
+      // sets new current menuItem
+      dispatch(setCurrentMenuItem(menuItem))
+    }
+  }
 
-  console.log(`menuItem order: ${menu.order}, menuItem height: ${postHeight}`)
+  useEffect(() => {
+    // on mount listens to scroll events
+    window.addEventListener("scroll", scrollHandler)
+    // on dismount stops listening for scroll events
+    return () => window.removeEventListener("scroll", scrollHandler)
+  }, [scrollHandler])
+
+  const menuItemRef = useCallback(
+    // reference to DOM node
+    (node) => {
+      // checks is node is rendered
+      if (node === null) return
+      // heigh of DOM node
+      const { height } = node.getBoundingClientRect()
+      // sets offset to top of node
+      setMenuItemOffsetTop(node.offsetTop)
+      // sets offset to bottom of node
+      setMenuItemOffsetBottom(height + node.offsetTop)
+      // callback fn to scroll to node offsettop
+      const scrollCallback = () => {
+        node.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        })
+      }
+      // dispatches fn to store with menuItem information
+      dispatch(setMenuItemCallback(menuItem, scrollCallback))
+    },
+    // checks all posts are rendered
+    [menuItem, postsLoaded !== posts.length]
+  )
 
   return (
-    <div
-      className="MenuItem"
-      id={menu._id}
-      ref={(ref) => {
-        setPostRef(ref)
-      }}
-    >
-      {Posts.map((post) => {
-        // const clientSortedAlphabetical = [...post].sort(
-        //   (a, b) => a.title - b.title
-        // )
-
-        // console.log("what is post?", post)
-        if (menu.order === post.postOrder)
-          return (
-            <img
-              key={post._id}
-              src={post.imageUrl}
-              ref={(ref) => {
-                if (!postRef) return
-                setPostHeight(postRef.offsetHeight)
-              }}
-            ></img>
-          )
-      })}
+    <div className="MenuItem" ref={menuItemRef}>
+      {posts.map((post) => (
+        <img
+          key={post.id}
+          src={post.imageUrl}
+          onLoad={() => setPostsLoaded(postsLoaded + 1)}
+        ></img>
+      ))}
     </div>
   )
 }

--- a/src/components/Post.scss
+++ b/src/components/Post.scss
@@ -1,12 +1,21 @@
 @import "../style/config";
 
 .MenuItem {
-  margin-bottom: 5px;
+  // margin-bottom: 5px;
+  padding-top: 25px;
+  padding-bottom: 500px;
+  &:not(:last-child) {
+    padding-bottom: 0;
+  }
+
   img {
-    display: inline-block;
+    display: block;
     width: 100%;
     margin: 0px;
     padding: 0px;
-    margin-bottom: 5px;
+    margin-bottom: 0px;
+    &:not(:last-child) {
+      padding-bottom: 5px;
+    }
   }
 }

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,26 +1,16 @@
-import React, { useEffect, createRef, useState } from "react"
+import React from "react"
 import "./Timeline.scss"
 import { useSelector } from "react-redux"
-import Post from "./Post"
 import { selectMenuItems } from "../store/homepage/selectors"
+import Post from "./Post"
 
 export default function Timeline() {
   const menuItems = useSelector(selectMenuItems)
-  const [itemHeight, setItemHeight] = useState(0)
-  const [itemRef, setItemRef] = useState()
-
-  // console.log("what is itemRef in Timeline?", itemRef)
-  console.log("what is itemHeight in Timeline?", itemHeight)
-
-  useEffect(() => {
-    if (!itemRef) return
-    setItemHeight(itemRef.offsetHeight)
-  }, [itemRef])
 
   return (
-    <div className="Timeline" ref={setItemRef}>
-      {menuItems.map((menu) => (
-        <Post menu={menu} key={menu._id} />
+    <div className="Timeline">
+      {menuItems.map((menuItem) => (
+        <Post key={menuItem.id} menuItem={menuItem} />
       ))}
     </div>
   )

--- a/src/components/Timeline.scss
+++ b/src/components/Timeline.scss
@@ -3,7 +3,7 @@
 .Timeline {
   position: relative;
   left: 45%;
-  padding: 25px;
+  // padding: 25px;
   padding-left: 40px;
   padding-right: 0px;
   top: 0;

--- a/src/pages/homepage.scss
+++ b/src/pages/homepage.scss
@@ -2,7 +2,7 @@
 
 .Homepage {
   // position: absolute;
-  padding: 15px;
+  // padding: 15px;
   padding-right: 0px;
   width: 100%;
   height: 100%;

--- a/src/store/homepage/actions.js
+++ b/src/store/homepage/actions.js
@@ -1,39 +1,70 @@
 import { sanityClient } from "../../index"
 import { fetchMenuItemsQuery, fetchPostsQuery } from "./queries"
-export const FETCH_POSTS_SUCCESS = "FETCH_POSTS_SUCCESS"
-export const FETCH_MENU_ITEMS_SUCCESS = "FETCH_MENU_ITEMS_SUCCESS"
 
+export const UPDATE_POSTS = "UPDATE_POSTS"
+export const UPDATE_MENU_ITEMS = "UPDATE_MENU_ITEMS"
+export const UPDATE_CURRENT_MENU_ITEM = "UPDATE_CURRENT_MENU_ITEM"
+export const UPDATE_MENU_ITEM = "UPDATE_MENU_ITEM"
+
+// fetches posts
 export const fetchPosts = () => async (dispatch, getState) => {
   await sanityClient.fetch(fetchPostsQuery).then((data) => {
+    // filters on title (asc)
     const sortedPosts = [...data].sort((a, b) => a.title - b.title)
-    dispatch(fetchPostsSuccess(sortedPosts))
+    dispatch(UpdatePosts(sortedPosts))
   })
 }
-const fetchPostsSuccess = (data) => {
+const UpdatePosts = (data) => {
   return {
-    type: FETCH_POSTS_SUCCESS,
+    type: UPDATE_POSTS,
     payload: data,
   }
 }
 
+// fetches menuItems
 export const fetchMenuItems = () => async (dispatch, getState) => {
   await sanityClient.fetch(fetchMenuItemsQuery).then((data) => {
-    dispatch(fetchMenuItemsSuccess(data))
-    //set default chapter to the 1st in the list
-    dispatch(setSelectedPost(data[0]._id))
+    dispatch(updateMenuItems(data))
+    // set selected menuItem to the 1st in the list
+    dispatch(setCurrentMenuItem(data[0]))
   })
 }
-const fetchMenuItemsSuccess = (data) => {
+const updateMenuItems = (data) => {
   return {
-    type: FETCH_MENU_ITEMS_SUCCESS,
+    type: UPDATE_MENU_ITEMS,
     payload: data,
   }
 }
 
-export const setSelectedPost = (data) => {
-  const SET_SELECTED_POST = "SET_SELECTED_POST"
+// sets current menuItem
+export const setCurrentMenuItem = (menuItem) => (dispatch, getState) => {
+  dispatch(updateCurrentMenuItem(menuItem))
+}
+const updateCurrentMenuItem = (data) => {
   return {
-    type: SET_SELECTED_POST,
-    payload: [data],
+    type: UPDATE_CURRENT_MENU_ITEM,
+    payload: data,
+  }
+}
+
+// receives 2 arguments, menuItem and a function, dispatches both to store
+export const setMenuItemCallback = (menuItem, callback) => (
+  dispatch,
+  getState
+) => {
+  dispatch(updateMenuItem(menuItem.id, { callback }))
+}
+
+// removes callback from store
+/*
+ export const unsetPostCallback = post => (dispatch, getState) => {
+ dispatch(updatePost(post.id, { callback: undefined }))
+ }
+*/
+
+const updateMenuItem = (id, data) => {
+  return {
+    type: UPDATE_MENU_ITEM,
+    payload: { id, data },
   }
 }

--- a/src/store/homepage/queries.js
+++ b/src/store/homepage/queries.js
@@ -1,19 +1,16 @@
 export const fetchMenuItemsQuery = `
 * [_type=="post"] | order (order, ASC){
-  _id,
+  "id": _id,
+  "slug": slug.current,
   order,
   title,
-  ...body[0]{
-    ...children[0]{
-     "body": text 
-    }
-  }
+  body,
 } 
 `
 
 export const fetchPostsQuery = `
 * [_type=="afbeeldingen"] | order (postOrder, ASC){
-  _id,
+  "id": _id,
   ...mainImage.asset->{
    "imageUrl": url,
   },

--- a/src/store/homepage/reducer.js
+++ b/src/store/homepage/reducer.js
@@ -1,24 +1,51 @@
 import {
-  FETCH_POSTS_SUCCESS,
-  FETCH_MENU_ITEMS_SUCCESS,
-  setSelectedPost,
+  UPDATE_MENU_ITEMS,
+  UPDATE_POSTS,
+  UPDATE_CURRENT_MENU_ITEM,
+  UPDATE_MENU_ITEM,
 } from "./actions.js"
 
 const initialState = {
-  menuItems: [],
+  menuItems: {},
   posts: [],
-  selectedPost: [],
+  currentMenuItem: undefined,
 }
 
 export default (state = initialState, { type, payload }) => {
   switch (type) {
-    case FETCH_POSTS_SUCCESS:
-      return { ...state, posts: [...state.posts, ...payload] }
-    case FETCH_MENU_ITEMS_SUCCESS:
-      return { ...state, menuItems: [...state.menuItems, ...payload] }
-    case "SET_SELECTED_POST":
-      return { ...state, selectedPost: [...payload] }
+    case UPDATE_MENU_ITEMS:
+      return {
+        ...state,
+        menuItems: {
+          ...state.menuItems,
+          // reduces payload to an object using .id as key
+          ...payload.reduce((acc, curr) => ({ ...acc, [curr.id]: curr }), {}),
+        },
+      }
 
+    //adds posts to store
+    case UPDATE_POSTS:
+      return { ...state, posts: state.posts.concat(payload) }
+
+    case UPDATE_CURRENT_MENU_ITEM:
+      return {
+        ...state,
+        // sets menuItem.id, replacing previous selected menuItem.id
+        currentMenuItem: payload,
+      }
+
+    //updates menuitem with callback function and menuItem.id
+    case UPDATE_MENU_ITEM:
+      return {
+        ...state,
+        menuItems: {
+          ...state.menuItems,
+          [payload.id]: {
+            ...(state.menuItems[payload.id] || {}),
+            ...payload.data,
+          },
+        },
+      }
     default:
       return state
   }

--- a/src/store/homepage/selectors.js
+++ b/src/store/homepage/selectors.js
@@ -1,3 +1,20 @@
-export const selectMenuItems = (state) => state.homepageData.menuItems
-export const selectedPost = (state) => state.homepageData.selectedPost
-export const selectPosts = (state) => state.homepageData.posts
+// creates array from object with menuItems
+export const selectMenuItems = (state) =>
+  Object.values(state.homepage.menuItems)
+
+// selects posts with postOrder number corresponding with menuItem.order number
+export const selectMenuItemsPosts = (menuItem) => (state) =>
+  state.homepage.posts.filter((post) => post.postOrder === menuItem.order)
+
+// create array from object of menuItemData, selects id, title, slug, callbackFn
+export const selectMenuItemData = (state) =>
+  Object.values(state.homepage.menuItems).map(
+    ({ id, title, slug, callback }) => ({
+      id,
+      title,
+      slug,
+      callback,
+    })
+  )
+
+export const selectCurrentMenuItem = (state) => state.homepage.currentMenuItem

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -1,8 +1,8 @@
 import { combineReducers } from "redux"
 import user from "./user/reducer"
-import homepageData from "./homepage/reducer"
+import homepage from "./homepage/reducer"
 
 export default combineReducers({
   user,
-  homepageData,
+  homepage,
 })


### PR DESCRIPTION
# Scroll event feature
#### Lots of new features and old changes in this branch. 
_Special thanks to [Tjerk Woudsma](https://github.com/woudsma) :pray:_ for helping me solve some obstacles I had while working on this feature.

![Aug-14-2020 23-57-44](https://user-images.githubusercontent.com/65892566/90295776-1ce76000-de8a-11ea-826f-a6e023ac538f.gif)
_- Now able to set_ **currentMenuItem** _by scrolling up/down_
_- Still able to set_ **currentMenuItem** _by clicking menuItem in the menuBar_

## Components
### Post.js
- I give a [useCallback](https://reactjs.org/docs/hooks-reference.html#usecallback) hook to every div ``<div className="MenuItem" ref={menuItemRef}>`` which in turn renders all corresponding images. 
- Dependencies check if all posts are loaded.
- After rendering local state is set with the DOM node's offsetTop, height and offsetBottom.
- I dispatch an action with callback fn and menuItem data as arguments.
``   const scrollCallback = () => {
        node.scrollIntoView({
          behavior: "smooth",
          block: "start",
        })
      }``
_(this callback fn is used later on to click menuItems in the menuBar.)_
- useEffect initiates scroll event listener 
-**scrollHandler** listens to scroll and fires an action that sets new currentMenuItem according to local state set by the useCallback hook.

### MenuBar.js
- menuBar renders a <Link> for every menuItem in the store
- menuItem onClick will fire the **scrollCallback** (to the specific node's offsetTop)
- if currentMenuItem.title === menuItem.title, color is set to black.

## Store
### Actions
- renamed 'action-name'Success to update'action-name' for clarity
- added setMenuItemCallback to store callback in store

### Reducers
- in UPDATE_MENU_ITEMS I use .reduce to create an object containing menuItem.id as key (so I don't have to map through it every time I use it)
- UPDATE_MENU_ITEM stores callback fn 

### Selectors
- selectMenuItemsPosts selects posts filtered on corresponding menuItem.order number.:
``export const selectMenuItemsPosts = (menuItem) => (state) =>
  state.homepage.posts.filter((post) => post.postOrder === menuItem.order)``
- This is given as parameter in Post.js: ``
  const posts = useSelector(selectMenuItemsPosts(menuItem))``

### Queries
- I changed _id to id for simplicity
- body data is fetched whole and mapped using selectors so I could easily access other elements from Sanity (Slug for example) which can be used in the future.

## Styling
- basic styling was added to remove any unwanted padding/margin and display:inline-block  spaces.

_App is now almost perfectly copied from its older state, next up:
Responsiveness :elephant: > :ant:_