### PR TITLE
Bugfix rename queries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const { NODE_ENV, REACT_APP_SANITY_PROJECT_ID: PROJECT_ID } = process.env
 
 export const sanityClient = sanity({
   projectId: PROJECT_ID,
-  dataset: "production",
+  dataset: "production2",
   useCdn: NODE_ENV === "production",
 })
 

--- a/src/store/homepage/actions.js
+++ b/src/store/homepage/actions.js
@@ -10,7 +10,7 @@ export const UPDATE_MENU_ITEM = "UPDATE_MENU_ITEM"
 export const fetchPosts = () => async (dispatch, getState) => {
   await sanityClient.fetch(fetchPostsQuery).then((data) => {
     // filters on title (asc)
-    const sortedPosts = [...data].sort((a, b) => a.title - b.title)
+    const sortedPosts = [...data].sort((a, b) => a.order - b.order)
     dispatch(UpdatePosts(sortedPosts))
   })
 }

--- a/src/store/homepage/queries.js
+++ b/src/store/homepage/queries.js
@@ -1,5 +1,5 @@
 export const fetchMenuItemsQuery = `
-* [_type=="post"] | order (order, ASC){
+* [_type=="menuItem"] | order (order, ASC){
   "id": _id,
   "slug": slug.current,
   order,
@@ -9,16 +9,18 @@ export const fetchMenuItemsQuery = `
 `
 
 export const fetchPostsQuery = `
-* [_type=="afbeeldingen"] | order (postOrder, ASC){
+* [_type=="post"] | order (menuItemOrder, ASC){
   "id": _id,
   ...mainImage.asset->{
    "imageUrl": url,
   },
-  ...post->{
-  "postId": _id,
-  "postOrder": order
+  ...menuItem->{
+  "menuItemId": _id,
+  "menuItemOrder": order
   },
   seasons,
-  title
+  title,
+  order,
+  "slug": slug.current,
 }
 `

--- a/src/store/homepage/selectors.js
+++ b/src/store/homepage/selectors.js
@@ -4,7 +4,7 @@ export const selectMenuItems = (state) =>
 
 // selects posts with postOrder number corresponding with menuItem.order number
 export const selectMenuItemsPosts = (menuItem) => (state) =>
-  state.homepage.posts.filter((post) => post.postOrder === menuItem.order)
+  state.homepage.posts.filter((post) => post.menuItemOrder === menuItem.order)
 
 // create array from object of menuItemData, selects id, title, slug, callbackFn
 export const selectMenuItemData = (state) =>


### PR DESCRIPTION
## Renaming

- I had to update the queries to match new sanity [schemas](https://github.com/timlaurijs/bijlaurijs-cms/tree/cleanup-clean-unwanted-features) (with new names)
- I had to update selector to menuIteOrder to match new sanity schemas
- Now sort on post.order instead post.title so image title can be descriptive instead of chronological. 
