### PR TITLE
Feature add season selector

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react"
 import "./Post.scss"
 import { useSelector, useDispatch } from "react-redux"
-import { selectMenuItemsPosts } from "../store/homepage/selectors"
+import { selectMenuItemsPosts, selectSeason } from "../store/homepage/selectors"
 import {
   setCurrentMenuItem,
   setMenuItemCallback,
@@ -11,8 +11,11 @@ import Map from "./Map"
 const Post = (props) => {
   const dispatch = useDispatch()
   const { menuItem } = props
+
   // selects posts of corresponding menuItem
-  const posts = useSelector(selectMenuItemsPosts(menuItem))
+  const season = useSelector(selectSeason)
+  const posts = useSelector(selectMenuItemsPosts(menuItem, season))
+
   // local states that store DOM node info
   const [menuItemOffsetTop, setMenuItemOffsetTop] = useState(0)
   const [menuItemOffsetBottom, setMenuItemOffsetBottom] = useState(0)

--- a/src/components/SeasonPicker.js
+++ b/src/components/SeasonPicker.js
@@ -1,0 +1,23 @@
+import React from "react"
+import "./SeasonPicker.scss"
+import { useDispatch } from "react-redux"
+import { setSeason } from "../store/homepage/actions"
+
+const SeasonPicker = () => {
+  const dispatch = useDispatch()
+
+  return (
+    <form className="SeasonPicker">
+      <label htmlFor="seasons">Selecteer een seizoen </label>
+      <select onChange={(event) => dispatch(setSeason(event.target.value))}>
+        <option value="year"> Alle seizoenen</option>
+        <option value="winter"> Winter</option>
+        <option value="spring"> Lente</option>
+        <option value="summer"> Zomer</option>
+        <option value="autumn"> Herfst</option>
+      </select>
+    </form>
+  )
+}
+
+export default SeasonPicker

--- a/src/components/SeasonPicker.scss
+++ b/src/components/SeasonPicker.scss
@@ -1,0 +1,7 @@
+@import "../style/config";
+
+.SeasonPicker {
+  // position: relative;
+  margin-left: 35px;
+  margin-bottom: 5%;
+}

--- a/src/pages/homepage.js
+++ b/src/pages/homepage.js
@@ -4,12 +4,14 @@ import Menubar from "../components/Menubar"
 import BodyText from "../components/BodyText"
 import Timeline from "../components/Timeline"
 import Footer from "../components/Footer"
+import SeasonPicker from "../components/SeasonPicker"
 
 export default function Homepage() {
   return (
     <div className="Homepage">
       <div className="menu-container">
         <Menubar />
+        <SeasonPicker />
         <BodyText />
       </div>
       <Timeline />

--- a/src/store/homepage/actions.js
+++ b/src/store/homepage/actions.js
@@ -7,6 +7,7 @@ export const UPDATE_CURRENT_MENU_ITEM = "UPDATE_CURRENT_MENU_ITEM"
 export const UPDATE_MENU_ITEM = "UPDATE_MENU_ITEM"
 export const APP_LOADING = "APP_LOADING"
 export const APP_DONE_LOADING = "APP_DONE_LOADING"
+export const UPDATE_SEASON = "UPDATE_SEASON"
 
 // fetches posts
 export const fetchPosts = () => async (dispatch, getState) => {
@@ -18,6 +19,7 @@ export const fetchPosts = () => async (dispatch, getState) => {
     dispatch(UpdatePosts(sortedPosts))
   })
 }
+
 export const appLoading = () => ({ type: APP_LOADING })
 export const appDoneLoading = () => ({ type: APP_DONE_LOADING })
 
@@ -73,5 +75,16 @@ const updateMenuItem = (id, data) => {
   return {
     type: UPDATE_MENU_ITEM,
     payload: { id, data },
+  }
+}
+
+// sets new season
+export const setSeason = (data) => (dispatch, getState) => {
+  dispatch(updateSeason(data))
+}
+const updateSeason = (data) => {
+  return {
+    type: UPDATE_SEASON,
+    payload: data,
   }
 }

--- a/src/store/homepage/reducer.js
+++ b/src/store/homepage/reducer.js
@@ -5,6 +5,7 @@ import {
   UPDATE_POSTS,
   UPDATE_CURRENT_MENU_ITEM,
   UPDATE_MENU_ITEM,
+  UPDATE_SEASON,
 } from "./actions.js"
 
 const initialState = {
@@ -12,6 +13,7 @@ const initialState = {
   posts: [],
   currentMenuItem: undefined,
   loading: false,
+  currentSeason: "year",
 }
 
 export default (state = initialState, { type, payload }) => {
@@ -55,6 +57,13 @@ export default (state = initialState, { type, payload }) => {
           },
         },
       }
+
+    case UPDATE_SEASON:
+      return {
+        ...state,
+        currentSeason: payload,
+      }
+
     default:
       return state
   }

--- a/src/store/homepage/selectors.js
+++ b/src/store/homepage/selectors.js
@@ -5,8 +5,22 @@ export const selectMenuItems = (state) =>
 export const isLoading = (state) => state.homepage.loading
 
 // selects posts with postOrder number corresponding with menuItem.order number
-export const selectMenuItemsPosts = (menuItem) => (state) =>
-  state.homepage.posts.filter((post) => post.menuItemOrder === menuItem.order)
+export const selectMenuItemsPosts = (menuItem, season) => (state) => {
+  const posts = state.homepage.posts.filter(
+    (post) => post.menuItemOrder === menuItem.order
+  )
+  const filteredPosts = [...posts].filter((post) => {
+    if (season === "year") {
+      return post
+    } else if (post.seasons === season) {
+      return post
+    }
+  })
+  return filteredPosts
+}
+
+// export const selectMenuItemsPosts = (menuItem) => (state) =>
+//   state.homepage.posts.filter((post) => post.menuItemOrder === menuItem.order)
 
 // create array from object of menuItemData, selects id, title, slug, callbackFn
 export const selectMenuItemData = (state) =>
@@ -20,3 +34,5 @@ export const selectMenuItemData = (state) =>
   )
 
 export const selectCurrentMenuItem = (state) => state.homepage.currentMenuItem
+
+export const selectSeason = (state) => state.homepage.currentSeason


### PR DESCRIPTION
## Seasons
added feature to filter trough images based on the season were taken in.
A user can select a season or all seasons with a dropdown menu underneath the menuBar.

### Logic
#### Action + Reducer
by default **currentSeason** will be set on 'year', when a user changes input to another season an action is triggered setting  new state to that season.

#### Selector
**selectMenuItemsPosts** gets an additional argument: 'season' and filteres posts on their season tag. This so I don't have to filter them in **Posts.js**. If year is the **currentSeason**, all posts will be shown.

### Todo:
eventually I want some sort of placeholder image/div-size that'll be rendered when there are no images in a menuItem when filtered.
E.g. when seasons set to _Winter_, only **menuItem** 'De Achterhoek' has posts with the _Winter_ tag. In this case I want to render a placeholder Image or div size so people will still be able to read the menu text.
Or, I want to remove all menuItems when a filter is turned on so users will only be able to view the filtered images. 

![Aug-20-2020 14-03-18](https://user-images.githubusercontent.com/65892566/90767843-1de71a00-e2ee-11ea-9e08-26493133295b.gif)

